### PR TITLE
Add event emitter for on click event

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: Build & test NPM package
 on:
   push:
-    branches: [develop,master]
+    branches: [develop,main]
   pull_request:
-    branches: [master]
+    branches: [main]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "[css]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[html]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[json]": { "editor.defaultFormatter": "esbenp.prettier-vscode" },
+  "[typescript]": { "editor.defaultFormatter": "esbenp.prettier-vscode" }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,51 @@
 # CHANGELOG
 
+## 14.1.0
+
+Pull request: https://github.com/philenius/ngx-annotate-text/pull/12
+
+- Adds the output `clickAnnotation` to the `ngx-annotate-text` component which emits the selected annotation when the user clicks on an annotation as requested in #10.
+- Adds the output `removeAnnotation` to the `ngx-annotate-text` component which emits the selected annotation when the user removes an annotation by clicking the annotation's X button in the upper right corner.
+
 ## 14.0.0
 
 Pull request: https://github.com/philenius/ngx-annotate-text/pull/11
 
-* Upgrade to Angular 14.2.12, thank you @miccou for your contribution
+- Upgrade to Angular 14.2.12, thank you @miccou for your contribution
 
 ## 13.0.0
 
 Pull request: https://github.com/philenius/ngx-annotate-text/pull/7
 
-* Upgrade to Angular 13.3.0
+- Upgrade to Angular 13.3.0
 
 ## 12.0.0
 
 Pull request: https://github.com/philenius/ngx-annotate-text/pull/6
 
-* Upgrade to Angular 12.2.0
+- Upgrade to Angular 12.2.0
 
 ## 11.0.0
 
 Pull request: https://github.com/philenius/ngx-annotate-text/pull/5
 
-* Upgrade to Angular 11.2.14
-* Replace TSLint by ESLint
-* Fix linting errors and errors due to strict null checks
-* Add new method `isOverlappingWithExistingAnnotations()` to check whether the current text selection overlaps with the existing annotations.
-
+- Upgrade to Angular 11.2.14
+- Replace TSLint by ESLint
+- Fix linting errors and errors due to strict null checks
+- Add new method `isOverlappingWithExistingAnnotations()` to check whether the current text selection overlaps with the existing annotations.
 
 ## 10.0.0
 
 Commit: https://github.com/philenius/ngx-annotate-text/commit/c2da60bef3b48a111ddfe486666b966e701beff1
 
-* Change versioning of this NPM package to align it with Angular versions (Angular 10.1.6)
-
+- Change versioning of this NPM package to align it with Angular versions (Angular 10.1.6)
 
 ## 0.1.4
 
 Pull request: https://github.com/philenius/ngx-annotate-text/pull/4
 
-* Replace import of `BrowserModule` by `CommonModule` to fix issue https://github.com/philenius/ngx-annotate-text/issues/2:
-   ```
-   BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead.
-   ```
-* Refactor code for tokenization and improve code coverage
+- Replace import of `BrowserModule` by `CommonModule` to fix issue https://github.com/philenius/ngx-annotate-text/issues/2:
+  ```
+  BrowserModule has already been loaded. If you need access to common directives such as NgIf and NgFor from a lazy loaded module, import CommonModule instead.
+  ```
+- Refactor code for tokenization and improve code coverage

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # ngx-annotate-text
 
-<img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/workflow/status/philenius/ngx-annotate-text/Build%20&%20test%20NPM%20package/master?style=for-the-badge"> <a href="https://github.com/philenius/ngx-annotate-text/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/philenius/ngx-annotate-text?style=for-the-badge"></a> <img alt="GitHub" src="https://img.shields.io/github/license/philenius/ngx-annotate-text?style=for-the-badge"> <img alt="npm" src="https://img.shields.io/npm/v/ngx-annotate-text?style=for-the-badge"> 
+<img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/actions/workflow/status/philenius/ngx-annotate-text/main.yml?branch=main&style=for-the-badge"> <a href="https://github.com/philenius/ngx-annotate-text/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/philenius/ngx-annotate-text?style=for-the-badge"></a> <img alt="GitHub" src="https://img.shields.io/github/license/philenius/ngx-annotate-text?style=for-the-badge"> <img alt="npm" src="https://img.shields.io/npm/v/ngx-annotate-text?style=for-the-badge"> 
 
 [![Edit ngx-annotate-text demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/ngx-annotate-text-demo-sgb4t1?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2Fapp.component.html&theme=dark)
 
 
 An Angular component library for interactively highlighting / annotating parts of text.
 
-![Screenshot](https://raw.githubusercontent.com/philenius/ngx-annotate-text/master/screenshot.png)
+![Screenshot](https://raw.githubusercontent.com/philenius/ngx-annotate-text/main/screenshot.png)
 
 ## Features
 
@@ -21,7 +21,7 @@ An Angular component library for interactively highlighting / annotating parts o
 
 [![Edit ngx-annotate-text demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/ngx-annotate-text-demo-sgb4t1?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2Fapp.component.html&theme=dark)
 
-View and edit the live demo Angular app on <a href="https://codesandbox.io/s/ngx-annotate-text-demo-sgb4t1?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2Fapp.component.html&theme=dark">codesandbox.io</a> or look through the code of the demo app in [ngx-annotate-text/src/app/](https://github.com/philenius/ngx-annotate-text/tree/master/src/app).
+View and edit the live demo Angular app on <a href="https://codesandbox.io/s/ngx-annotate-text-demo-sgb4t1?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2Fapp.component.html&theme=dark">codesandbox.io</a> or look through the code of the demo app in [ngx-annotate-text/src/app/](https://github.com/philenius/ngx-annotate-text/tree/main/src/app).
 
 
 
@@ -29,7 +29,7 @@ View and edit the live demo Angular app on <a href="https://codesandbox.io/s/ngx
 **Screen recording:**
 
 
-![Screen recording GIF](https://raw.githubusercontent.com/philenius/ngx-annotate-text/master/screen-recording.gif)
+![Screen recording GIF](https://raw.githubusercontent.com/philenius/ngx-annotate-text/main/screen-recording.gif)
 
 ## Usage
 
@@ -170,6 +170,8 @@ Run `ng lint ngx-annotate-text` to execute ESLint.
 Run `ng test ngx-annotate-text --code-coverage` to execute the unit tests via [Karma](https://karma-runner.github.io). Don't forget to set the environment variable for where to find Chrome / Chromium like so: `export CHROME_BIN=/snap/bin/chromium`.
 
 ### Publish library as an npm package
+
+:warning: Don't manually publish to npmjs.org, there is a pipeline that runs automatically when a new release is created.
 
 ```bash
 ng build ngx-annotate-text --configuration production

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
+
 # ngx-annotate-text
 
-<img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/actions/workflow/status/philenius/ngx-annotate-text/main.yml?branch=main&style=for-the-badge"> <a href="https://github.com/philenius/ngx-annotate-text/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/philenius/ngx-annotate-text?style=for-the-badge"></a> <img alt="GitHub" src="https://img.shields.io/github/license/philenius/ngx-annotate-text?style=for-the-badge"> <img alt="npm" src="https://img.shields.io/npm/v/ngx-annotate-text?style=for-the-badge"> 
+<img alt="GitHub Workflow Status (branch)" src="https://img.shields.io/github/actions/workflow/status/philenius/ngx-annotate-text/main.yml?branch=main&style=for-the-badge"> <a href="https://github.com/philenius/ngx-annotate-text/issues"><img alt="GitHub issues" src="https://img.shields.io/github/issues/philenius/ngx-annotate-text?style=for-the-badge"></a> <img alt="GitHub" src="https://img.shields.io/github/license/philenius/ngx-annotate-text?style=for-the-badge"> <img alt="npm" src="https://img.shields.io/npm/v/ngx-annotate-text?style=for-the-badge">
 
 [![Edit ngx-annotate-text demo](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/ngx-annotate-text-demo-sgb4t1?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2Fapp.component.html&theme=dark)
-
 
 An Angular component library for interactively highlighting / annotating parts of text.
 
@@ -11,11 +11,9 @@ An Angular component library for interactively highlighting / annotating parts o
 
 ## Features
 
-* :point_up_2: Interactively mark entities such as cities, numbers, dates, etc.
-* :wastebasket: Interactively remove annotations / marked entities. 
-* :tada: Purely based on CSS. No magic, no canvas, and no SVGs.
-
-
+- :point_up_2: Interactively mark entities such as cities, numbers, dates, etc.
+- :wastebasket: Interactively remove annotations / marked entities.
+- :tada: Purely based on CSS. No magic, no canvas, and no SVGs.
 
 ## Demo
 
@@ -23,11 +21,7 @@ An Angular component library for interactively highlighting / annotating parts o
 
 View and edit the live demo Angular app on <a href="https://codesandbox.io/s/ngx-annotate-text-demo-sgb4t1?fontsize=14&hidenavigation=1&module=%2Fsrc%2Fapp%2Fapp.component.html&theme=dark">codesandbox.io</a> or look through the code of the demo app in [ngx-annotate-text/src/app/](https://github.com/philenius/ngx-annotate-text/tree/main/src/app).
 
-
-
-
 **Screen recording:**
-
 
 ![Screen recording GIF](https://raw.githubusercontent.com/philenius/ngx-annotate-text/main/screen-recording.gif)
 
@@ -35,106 +29,98 @@ View and edit the live demo Angular app on <a href="https://codesandbox.io/s/ngx
 
 1. Install the NPM package:
 
-    ```bash
-    npm install ngx-annotate-text
-    ```
+   ```bash
+   npm install ngx-annotate-text
+   ```
 
 2. Import the Angular module `NgxAnnotateTextModule`:
 
-    ```typescript
-    import { BrowserModule } from '@angular/platform-browser';
-    import { NgModule } from '@angular/core';
-    
-    import { AppComponent } from './app.component';
-    import { NgxAnnotateTextModule } from 'ngx-annotate-text';
-    
-    @NgModule({
-      declarations: [
-        AppComponent
-      ],
-      imports: [
-        BrowserModule,
-        NgxAnnotateTextModule,
-      ],
-      providers: [],
-      bootstrap: [AppComponent]
-    })
-    export class AppModule { }
-    ```
+   ```typescript
+   import { BrowserModule } from "@angular/platform-browser";
+   import { NgModule } from "@angular/core";
 
-3. Add the component `ngx-annotate-text`  to your template:
+   import { AppComponent } from "./app.component";
+   import { NgxAnnotateTextModule } from "ngx-annotate-text";
 
-    ```html
-    <ngx-annotate-text
-    	[(annotations)]="annotations"
-     	[removable]="true"
-    	[text]="text"
-    	annotationClass="my-annotation"
-    	#annotateText>
-    </ngx-annotate-text>
-    ```
+   @NgModule({
+     declarations: [AppComponent],
+     imports: [BrowserModule, NgxAnnotateTextModule],
+     providers: [],
+     bootstrap: [AppComponent],
+   })
+   export class AppModule {}
+   ```
+
+3. Add the component `ngx-annotate-text` to your template:
+
+   ```html
+   <ngx-annotate-text
+     [(annotations)]="annotations"
+     [removable]="true"
+     [text]="text"
+     annotationClass="my-annotation"
+     #annotateText
+   >
+   </ngx-annotate-text>
+   ```
 
 4. Create properties in your component class for the text to be annotated and an (empty) array of annotations:
 
-    ```typescript
-    import { Component, ViewChild } from '@angular/core';
-    import { Annotation, NgxAnnotateTextComponent } from 'ngx-annotate-text';
-    
-    @Component({
-      selector: 'app-root',
-      templateUrl: './app.component.html',
-      styleUrls: ['./app.component.css']
-    })
-    export class AppComponent {
-    
-      text: string = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
-    
-      annotations: Annotation[] = [
-        new Annotation(3, 11, 'Date', '#0069d9'),
-        new Annotation(36, 45, 'City', '#dc3545'),
-        new Annotation(47, 52, 'Country', '#28a745'),
-        new Annotation(77, 85, 'Time', '#5a6268'),
-      ];
-    
-    }
-    ```
+   ```typescript
+   import { Component, ViewChild } from "@angular/core";
+   import { Annotation, NgxAnnotateTextComponent } from "ngx-annotate-text";
 
-5. Having set `annotationClass="my-annotation"`, a custom CSS styling can be applied by combining `::ng-deep` with the class selector `.my-annotation`, e.g., to remove the border-radius: 
+   @Component({
+     selector: "app-root",
+     templateUrl: "./app.component.html",
+     styleUrls: ["./app.component.css"],
+   })
+   export class AppComponent {
+     text: string =
+       "On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.";
+
+     annotations: Annotation[] = [
+       new Annotation(3, 11, "Date", "#0069d9"),
+       new Annotation(36, 45, "City", "#dc3545"),
+       new Annotation(47, 52, "Country", "#28a745"),
+       new Annotation(77, 85, "Time", "#5a6268"),
+     ];
+   }
+   ```
+
+5. Having set `annotationClass="my-annotation"`, a custom CSS styling can be applied by combining `::ng-deep` with the class selector `.my-annotation`, e.g., to remove the border-radius:
    ```css
    ::ng-deep .my-annotation .annotation-parent,
    ::ng-deep .my-annotation .annotation-content {
-       border-radius: 0rem !important;
+     border-radius: 0rem !important;
    }
    ```
-   
-
-
 
 ## API - NgxAnnotateText
 
 ### Inputs
 
-| Input           | Description                                                  | Type         | Default value |
-| :-------------- | ------------------------------------------------------------ | ------------ | :------------ |
-| annotations     | Represents the parts of the given text which shall be annotated. | `Annotation[]` | `[]`            |
-| annotationClass | An optional CSS class applied to all elements which wrap the annotated parts of the given text. | `string\|undefined`       | `undefined`               |
-| removable       | Determines whether annotations shall have a small button in the top right corner so that the user can remove an annotation. | `boolean`      | `true`           |
-| text            | The text which shall be displayed and annotated.             | `string`       | empty string              |
+| Input           | Description                                                  | Type               | Default value |
+| :-------------- | ------------------------------------------------------------ | ------------------ | :------------ |
+| annotations     | Represents the parts of the given text which shall be annotated. | `Annotation[]`     | `[]`          |
+| annotationClass | An optional CSS class applied to all elements which wrap the annotated parts of the given text. | `string|undefined` | `undefined`   |
+| removable       | Determines whether annotations shall have a small button in the top right corner so that the user can remove an annotation. | `boolean`          | `true`        |
+| text            | The text which shall be displayed and annotated.             | `string`           | empty string  |
 
 ### Outputs
 
-| Output            | Description                                                  | Type                       |
-| ----------------- | ------------------------------------------------------------ | -------------------------- |
-| annotationsChange | Emits the list of existing annotations after an element has been removed by the user. | `EventEmitter<Annotation[]>` |
+| Output            | Description                                                                                                             | Type                         |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| annotationsChange | Emits the list of existing annotations after an element has been removed by the user.                                   | `EventEmitter<Annotation[]>` |
+| clickAnnotation   | Emits the selected annotation when the user clicks on an annotation's box, the label or text.                           | `EventEmitter<Annotation>`   |
+| removeAnnotation  | Emits the selected annotation when the user removes it by clicking the annotation's X button in the upper right corner. | `EventEmitter<Annotation>`   |
 
 ### Methods
 
-| Method                               | Description                                                  | Return type |
-| ------------------------------------ | ------------------------------------------------------------ | ----------- |
-| getCurrentTextSelection              | Returns the start index and end index of the currently selected text range. Returns `undefined` if no text is currently selected. | `ISelection\|undefined` |
-| isOverlappingWithExistingAnnotations | Returns true if the given text selection is (partially) overlapping with an existing annotation. Returns false otherwise. | `boolean` |
-
-
+| Method                               | Description                                                  | Return type            |
+| ------------------------------------ | ------------------------------------------------------------ | ---------------------- |
+| getCurrentTextSelection              | Returns the start index and end index of the currently selected text range. Returns `undefined` if no text is currently selected. | `ISelection|undefined` |
+| isOverlappingWithExistingAnnotations | Returns true if the given text selection is (partially) overlapping with an existing annotation. Returns false otherwise. | `boolean`              |
 
 ## Development
 
@@ -183,9 +169,9 @@ npm publish
 
 Build the library in watch mode:
 
- ```bash
+```bash
 ng build ngx-annotate-text --watch
- ```
+```
 
 Run the Angular dev server:
 

--- a/projects/ngx-annotate-text/package.json
+++ b/projects/ngx-annotate-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-annotate-text",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "author": "Philipp Perez, (https://philenius.github.io)",
   "license": "MIT",
   "description": "An Angular component library for interactively highlighting / annotating parts of text.",

--- a/projects/ngx-annotate-text/src/lib/components/annotation/annotation.component.html
+++ b/projects/ngx-annotate-text/src/lib/components/annotation/annotation.component.html
@@ -1,11 +1,15 @@
-<span *ngIf="annotation" class="annotation-parent" [style.border-color]="annotation.color"
-    [style.background-color]="annotation.color">
+<span
+  *ngIf="annotation"
+  class="annotation-parent"
+  [style.border-color]="annotation.color"
+  [style.background-color]="annotation.color"
+  (click)="clickAnnotation.emit(annotation)"
+>
+  <span class="annotation-content">
+    <pre>{{ annotation.text }}</pre>
+  </span>
 
-    <span class="annotation-content">
-        <pre>{{ annotation.text }}</pre>
-    </span>
-
-    <!-- Instead of setting the property "innerText" of this HTML element, we set "data-label". In CSS, we can then
+  <!-- Instead of setting the property "innerText" of this HTML element, we set "data-label". In CSS, we can then
         reference the content of this property and can use the CSS pseudo- element "::after" to insert the content
         of "data-label" as text into the DOM. What's the advantage of this? At first, I tried to use the "innerText"
         property of this HTML element to visualize the annotation's label. Whenever the user selected a range of the
@@ -13,14 +17,19 @@
         extract which text range the user actually selected. By using the CSS pseudo-class "::after", we can prevent
         the annotations' labels from being included into the selected text range. -->
 
-    <span class="annotation-label" [attr.data-label]="annotation.label" [style.background-color]="annotation.color">
-    </span>
+  <span
+    class="annotation-label"
+    [attr.data-label]="annotation.label"
+    [style.background-color]="annotation.color"
+  >
+  </span>
 
-    <span class="annotation-button" *ngIf="removable">
-        <span>
-            <button class="remove-annotation" (click)="removeAnnotation.emit(annotation)">
-            </button>
-        </span>
+  <span class="annotation-button" *ngIf="removable">
+    <span>
+      <button
+        class="remove-annotation"
+        (click)="removeAnnotation.emit(annotation)"
+      ></button>
     </span>
-
+  </span>
 </span>

--- a/projects/ngx-annotate-text/src/lib/components/annotation/annotation.component.spec.ts
+++ b/projects/ngx-annotate-text/src/lib/components/annotation/annotation.component.spec.ts
@@ -4,18 +4,19 @@ import { Annotation } from '../../models/annotation.model';
 import { AnnotationComponent } from './annotation.components';
 
 describe('AnnotationComponent', () => {
-
   let component: AnnotationComponent;
   let fixture: ComponentFixture<AnnotationComponent>;
-  let getAnnotationContentElement = (): HTMLElement => fixture.nativeElement.querySelector('span.annotation-content pre');
-  let getAnnotationLabelElement = (): HTMLElement => fixture.nativeElement.querySelector('span.annotation-label');
-  let getAnnotationParentElement = (): HTMLElement => fixture.nativeElement.querySelector('span.annotation-parent');
+  let getAnnotationContentElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector('span.annotation-content pre');
+  let getAnnotationLabelElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector('span.annotation-label');
+  let getAnnotationParentElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector('span.annotation-parent');
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AnnotationComponent]
-    })
-      .compileComponents();
+      declarations: [AnnotationComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -41,7 +42,9 @@ describe('AnnotationComponent', () => {
 
     fixture.detectChanges();
 
-    expect(getAnnotationLabelElement().getAttribute('data-label')).toBe(annotation.label);
+    expect(getAnnotationLabelElement().getAttribute('data-label')).toBe(
+      annotation.label
+    );
   });
 
   it('should set the border color of the annotation to the specified color', () => {
@@ -51,7 +54,9 @@ describe('AnnotationComponent', () => {
 
     fixture.detectChanges();
 
-    expect(getAnnotationParentElement().style.borderColor).toBe(annotation.color);
+    expect(getAnnotationParentElement().style.borderColor).toBe(
+      annotation.color
+    );
   });
 
   it(`should set the background color of the annotation's label to the specified color`, () => {
@@ -61,7 +66,9 @@ describe('AnnotationComponent', () => {
 
     fixture.detectChanges();
 
-    expect(getAnnotationLabelElement().style.backgroundColor).toBe(annotation.color);
+    expect(getAnnotationLabelElement().style.backgroundColor).toBe(
+      annotation.color
+    );
   });
 
   it('should display a button to remove the annotation if removable == true', () => {
@@ -72,7 +79,9 @@ describe('AnnotationComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelector('button.remove-annotation')).toBeDefined();
+    expect(
+      fixture.nativeElement.querySelector('button.remove-annotation')
+    ).toBeDefined();
   });
 
   it('should not display a button to remove the annotation if removable == false', () => {
@@ -83,7 +92,9 @@ describe('AnnotationComponent', () => {
 
     fixture.detectChanges();
 
-    expect(fixture.nativeElement.querySelector('button.remove-annotation')).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector('button.remove-annotation')
+    ).toBeNull();
   });
 
   it('should remove the annotation on clicking the remove button', async () => {
@@ -103,4 +114,51 @@ describe('AnnotationComponent', () => {
     });
   });
 
+  it("should emit an event when the user clicks on the annotation's box", async () => {
+    spyOn(component.clickAnnotation, 'emit');
+
+    const annotation = new Annotation(0, 13, 'City', 'rgb(60, 65, 75)');
+    annotation.text = 'San Francisco';
+    component.annotation = annotation;
+
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('span.annotation-parent').click();
+
+    fixture.whenStable().then(() => {
+      expect(component.clickAnnotation.emit).toHaveBeenCalledWith(annotation);
+    });
+  });
+
+  it("should emit an event when the user clicks on the annotation's text", async () => {
+    spyOn(component.clickAnnotation, 'emit');
+
+    const annotation = new Annotation(0, 11, 'City', 'rgb(0, 255, 255)');
+    annotation.text = 'Los Angeles';
+    component.annotation = annotation;
+
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('span.annotation-content').click();
+
+    fixture.whenStable().then(() => {
+      expect(component.clickAnnotation.emit).toHaveBeenCalledWith(annotation);
+    });
+  });
+
+  it("should emit an event when the user clicks on the annotation's label", async () => {
+    spyOn(component.clickAnnotation, 'emit');
+
+    const annotation = new Annotation(0, 9, 'City', 'rgb(255, 255, 0)');
+    annotation.text = 'Frankfurt';
+    component.annotation = annotation;
+
+    fixture.detectChanges();
+
+    fixture.nativeElement.querySelector('span.annotation-label').click();
+
+    fixture.whenStable().then(() => {
+      expect(component.clickAnnotation.emit).toHaveBeenCalledWith(annotation);
+    });
+  });
 });

--- a/projects/ngx-annotate-text/src/lib/components/annotation/annotation.components.ts
+++ b/projects/ngx-annotate-text/src/lib/components/annotation/annotation.components.ts
@@ -11,6 +11,7 @@ export class AnnotationComponent {
 
   @Input() annotation?: Annotation;
   @Input() removable = true;
+  @Output() clickAnnotation = new EventEmitter<Annotation>();
   @Output() removeAnnotation = new EventEmitter<Annotation>();
 
   constructor() { }

--- a/projects/ngx-annotate-text/src/lib/components/ngx-annotate-text/ngx-annotate-text.component.html
+++ b/projects/ngx-annotate-text/src/lib/components/ngx-annotate-text/ngx-annotate-text.component.html
@@ -1,9 +1,13 @@
 <span *ngFor="let token of tokens">
-
-  <ngx-annotation *ngIf="isAnnotation(token)" [annotation]="token" [removable]="removable"
-    (removeAnnotation)="onRemoveAnnotation($event)" [class]="(annotationClass || '')">
+  <ngx-annotation
+    *ngIf="isAnnotation(token)"
+    [annotation]="token"
+    [removable]="removable"
+    (removeAnnotation)="onRemoveAnnotation($event)"
+    (clickAnnotation)="clickAnnotation.emit($event)"
+    [class]="annotationClass || ''"
+  >
   </ngx-annotation>
 
   <span *ngIf="!isAnnotation(token)" class="unlabeled">{{ token }}</span>
-
 </span>

--- a/projects/ngx-annotate-text/src/lib/components/ngx-annotate-text/ngx-annotate-text.component.spec.ts
+++ b/projects/ngx-annotate-text/src/lib/components/ngx-annotate-text/ngx-annotate-text.component.spec.ts
@@ -12,32 +12,29 @@ describe('NgxAnnotateTextComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [
-        NgxAnnotateTextComponent,
-        AnnotationComponent,
-      ]
+      declarations: [NgxAnnotateTextComponent, AnnotationComponent],
     });
 
     fixture = TestBed.createComponent(NgxAnnotateTextComponent);
     component = fixture.componentInstance;
-
   });
 
   it('should display the whole text when there are no initial annotations', () => {
-    const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+    const text =
+      'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
     component.text = text;
     fixture.detectChanges();
 
-    const textSpanElement = fixture.debugElement.nativeElement.querySelector('span:first-of-type');
+    const textSpanElement =
+      fixture.debugElement.nativeElement.querySelector('span:first-of-type');
     expect(textSpanElement.textContent).toBe(text);
   });
 
   it('should display the whole given text as a single annotated token', () => {
-    const annotations = [
-      new Annotation(0, 86, 'Annotation', 'red'),
-    ];
-    const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+    const annotations = [new Annotation(0, 86, 'Annotation', 'red')];
+    const text =
+      'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
     component.annotations = annotations;
     component.text = text;
@@ -48,20 +45,20 @@ describe('NgxAnnotateTextComponent', () => {
     expect((component.tokens[0] as Annotation).text).toBe(text);
   });
 
-  // it('should correctly determine the type of a token', () => {
-  //   const annotation: Annotation = new Annotation(0, 5, 'Token', 'black');
-  //   annotation.text = 'Hello';
+  it('should correctly determine the type of a token', () => {
+    const annotation: Annotation = new Annotation(0, 5, 'Token', 'black');
+    annotation.text = 'Hello';
 
-  //   expect(component.isAnnotation(annotation)).toBeTrue();
-  //   expect(component.isAnnotation('Hello')).toBeFalse();
-  // });
+    expect(component.isAnnotation(annotation)).toBeTrue();
+    expect(component.isAnnotation('Hello')).toBeFalse();
+  });
 
   it('should emit an empty list of annotations if the only annotation has been removed', () => {
     spyOn(component.annotationsChange, 'emit');
-    const annotations = [
-      new Annotation(36, 45, 'City', 'red'),
-    ];
-    const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+    spyOn(component.removeAnnotation, 'emit');
+    const annotations = [new Annotation(36, 45, 'City', 'red')];
+    const text =
+      'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
     component.annotations = annotations;
     component.text = text;
@@ -69,30 +66,38 @@ describe('NgxAnnotateTextComponent', () => {
     fixture.detectChanges();
 
     expect(component.annotationsChange.emit).toHaveBeenCalledWith([]);
+    expect(component.removeAnnotation.emit).toHaveBeenCalledWith(
+      annotations[0]
+    );
     expect(component.annotations.length).toBe(0);
   });
 
   it('should emit the list of remaining annotations if an annotation has been removed', () => {
     spyOn(component.annotationsChange, 'emit');
+    spyOn(component.removeAnnotation, 'emit');
     const annotations = [
       new Annotation(36, 45, 'City', 'red'),
       new Annotation(47, 52, 'Country', 'red'),
     ];
-    const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+    const text =
+      'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
     component.annotations = annotations;
     component.text = text;
     component.onRemoveAnnotation(annotations[0]);
     fixture.detectChanges();
 
-    expect(component.annotationsChange.emit).toHaveBeenCalledWith([annotations[1]]);
+    expect(component.annotationsChange.emit).toHaveBeenCalledWith([
+      annotations[1],
+    ]);
+    expect(component.removeAnnotation.emit).toHaveBeenCalledWith(
+      annotations[0]
+    );
     expect(component.annotations.length).toBe(1);
   });
 
   it('should recompute the list of tokens if the text input has changed', () => {
-    component.annotations = [
-      new Annotation(0, 5, 'Token', 'red'),
-    ];
+    component.annotations = [new Annotation(0, 5, 'Token', 'red')];
     component.text = 'Hello, world';
     fixture.detectChanges();
 
@@ -101,7 +106,11 @@ describe('NgxAnnotateTextComponent', () => {
 
     component.text = 'Now, with an updated message.';
     component.ngOnChanges({
-      text: new SimpleChange('Hello, world', 'Now, with an updated message.', false),
+      text: new SimpleChange(
+        'Hello, world',
+        'Now, with an updated message.',
+        false
+      ),
     });
     fixture.detectChanges();
 
@@ -110,9 +119,7 @@ describe('NgxAnnotateTextComponent', () => {
   });
 
   it('should recompute the list of tokens if the annotations input has changed', () => {
-    component.annotations = [
-      new Annotation(0, 5, 'Token1', 'red'),
-    ];
+    component.annotations = [new Annotation(0, 5, 'Token1', 'red')];
     component.text = 'Hello, world';
     fixture.detectChanges();
 
@@ -135,9 +142,9 @@ describe('NgxAnnotateTextComponent', () => {
   });
 
   describe('getCurrentTextSelection()', () => {
-
     it('should return `undefined` if no text is selected', () => {
-      const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+      const text =
+        'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
       component.text = text;
       const selection = window.getSelection();
@@ -148,12 +155,14 @@ describe('NgxAnnotateTextComponent', () => {
     });
 
     it('should return the correct boundaries if the whole text is selected', () => {
-      const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+      const text =
+        'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
       component.text = text;
       fixture.detectChanges();
 
-      const node = fixture.debugElement.nativeElement.querySelector('span:first-of-type');
+      const node =
+        fixture.debugElement.nativeElement.querySelector('span:first-of-type');
       const selection = window.getSelection();
       const range = document.createRange();
       range.selectNodeContents(node);
@@ -166,7 +175,8 @@ describe('NgxAnnotateTextComponent', () => {
     });
 
     it('should return the correct boundaries if the beginning of the text is selected', () => {
-      const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+      const text =
+        'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
       component.text = text;
       fixture.detectChanges();
@@ -179,7 +189,8 @@ describe('NgxAnnotateTextComponent', () => {
     });
 
     it('should return the correct boundaries if the middle of the text is selected', () => {
-      const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+      const text =
+        'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
       component.text = text;
       fixture.detectChanges();
@@ -192,7 +203,8 @@ describe('NgxAnnotateTextComponent', () => {
     });
 
     it('should return the correct boundaries if the end of the text is selected', () => {
-      const text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+      const text =
+        'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
       component.text = text;
       fixture.detectChanges();
@@ -203,11 +215,9 @@ describe('NgxAnnotateTextComponent', () => {
       expect(component.getCurrentTextSelection()!.startIndex).toBe(76);
       expect(component.getCurrentTextSelection()!.endIndex).toBe(86);
     });
-
   });
 
   describe('isOverlappingWithExistingAnnotations()', () => {
-
     it('should return false if there is no annotation that overlaps with the selection', () => {
       const selection: ISelection = {
         startIndex: 5,
@@ -220,7 +230,9 @@ describe('NgxAnnotateTextComponent', () => {
         new Annotation(16, 22, 'Article', 'yellow'),
       ];
 
-      expect(component.isOverlappingWithExistingAnnotations(selection)).toBeFalse();
+      expect(
+        component.isOverlappingWithExistingAnnotations(selection)
+      ).toBeFalse();
     });
 
     /**
@@ -233,11 +245,11 @@ describe('NgxAnnotateTextComponent', () => {
         endIndex: 12,
       };
 
-      component.annotations = [
-        new Annotation(5, 12, 'Noun', 'blue'),
-      ];
+      component.annotations = [new Annotation(5, 12, 'Noun', 'blue')];
 
-      expect(component.isOverlappingWithExistingAnnotations(selection)).toBeTrue();
+      expect(
+        component.isOverlappingWithExistingAnnotations(selection)
+      ).toBeTrue();
     });
 
     /**
@@ -250,11 +262,11 @@ describe('NgxAnnotateTextComponent', () => {
         endIndex: 6,
       };
 
-      component.annotations = [
-        new Annotation(4, 8, 'Verb', 'red'),
-      ];
+      component.annotations = [new Annotation(4, 8, 'Verb', 'red')];
 
-      expect(component.isOverlappingWithExistingAnnotations(selection)).toBeTrue();
+      expect(
+        component.isOverlappingWithExistingAnnotations(selection)
+      ).toBeTrue();
     });
 
     /**
@@ -267,11 +279,11 @@ describe('NgxAnnotateTextComponent', () => {
         endIndex: 12,
       };
 
-      component.annotations = [
-        new Annotation(4, 8, 'Adjective', 'orange'),
-      ];
+      component.annotations = [new Annotation(4, 8, 'Adjective', 'orange')];
 
-      expect(component.isOverlappingWithExistingAnnotations(selection)).toBeTrue();
+      expect(
+        component.isOverlappingWithExistingAnnotations(selection)
+      ).toBeTrue();
     });
 
     /**
@@ -284,11 +296,11 @@ describe('NgxAnnotateTextComponent', () => {
         endIndex: 8,
       };
 
-      component.annotations = [
-        new Annotation(4, 10, 'Adjective', 'orange'),
-      ];
+      component.annotations = [new Annotation(4, 10, 'Adjective', 'orange')];
 
-      expect(component.isOverlappingWithExistingAnnotations(selection)).toBeTrue();
+      expect(
+        component.isOverlappingWithExistingAnnotations(selection)
+      ).toBeTrue();
     });
 
     /**
@@ -301,17 +313,17 @@ describe('NgxAnnotateTextComponent', () => {
         endIndex: 10,
       };
 
-      component.annotations = [
-        new Annotation(6, 8, 'Adjective', 'orange'),
-      ];
+      component.annotations = [new Annotation(6, 8, 'Adjective', 'orange')];
 
-      expect(component.isOverlappingWithExistingAnnotations(selection)).toBeTrue();
+      expect(
+        component.isOverlappingWithExistingAnnotations(selection)
+      ).toBeTrue();
     });
-
   });
 
   function selectTextRangeInDocument(start: number, end: number): void {
-    const node = fixture.debugElement.nativeElement.querySelector('span.unlabeled');
+    const node =
+      fixture.debugElement.nativeElement.querySelector('span.unlabeled');
     const selection = window.getSelection();
     const range = document.createRange();
     range.setStart(node.childNodes[0], start);

--- a/projects/ngx-annotate-text/src/lib/components/ngx-annotate-text/ngx-annotate-text.component.ts
+++ b/projects/ngx-annotate-text/src/lib/components/ngx-annotate-text/ngx-annotate-text.component.ts
@@ -1,4 +1,13 @@
-import { Component, ElementRef, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+} from '@angular/core';
 import { Annotation } from '../../models/annotation.model';
 import { ISelection } from '../../models/selection.model';
 import { TokenizerService } from '../../services/tokenizer.service';
@@ -7,10 +16,9 @@ import { TokenizerService } from '../../services/tokenizer.service';
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'ngx-annotate-text',
   templateUrl: './ngx-annotate-text.component.html',
-  styleUrls: ['./ngx-annotate-text.component.css']
+  styleUrls: ['./ngx-annotate-text.component.css'],
 })
 export class NgxAnnotateTextComponent implements OnInit, OnChanges {
-
   /** Represents the parts of the given text which shall be annotated. */
   @Input() annotations: Annotation[] = [];
 
@@ -27,35 +35,58 @@ export class NgxAnnotateTextComponent implements OnInit, OnChanges {
   @Input() text = '';
 
   /** Emits the list of existing annotations after an element has been removed. */
-  @Output() annotationsChange: EventEmitter<Annotation[]> = new EventEmitter<Annotation[]>();
+  @Output() annotationsChange: EventEmitter<Annotation[]> = new EventEmitter<
+    Annotation[]
+  >();
+
+  /** Emits the selected annotation when the user clicks on an annotation's box, the label or text. */
+  @Output() clickAnnotation: EventEmitter<Annotation> =
+    new EventEmitter<Annotation>();
+
+  /** Emits the selected annotation when the user removes it by clicking the annotation's X button in the upper right corner. */
+  @Output() removeAnnotation: EventEmitter<Annotation> =
+    new EventEmitter<Annotation>();
 
   /** @internal */
   tokens: any[] = [];
   private selectionStart?: number;
   private selectionEnd?: number;
 
-  constructor(private elementRef: ElementRef, private tokenService: TokenizerService) { }
+  constructor(
+    private elementRef: ElementRef,
+    private tokenService: TokenizerService
+  ) {}
 
   ngOnInit(): void {
-    this.tokens = this.tokenService.splitTextIntoTokens(this.text, this.annotations);
+    this.tokens = this.tokenService.splitTextIntoTokens(
+      this.text,
+      this.annotations
+    );
   }
 
   ngOnChanges(changes: SimpleChanges): void {
     if ('annotations' in changes || 'text' in changes) {
-      this.tokens = this.tokenService.splitTextIntoTokens(this.text, this.annotations);
+      this.tokens = this.tokenService.splitTextIntoTokens(
+        this.text,
+        this.annotations
+      );
     }
   }
 
   /**
    * Provides start and end index of the currently selected text.
-   * 
+   *
    * @returns Returns the start index and end index of the currently selected text range. Returns `undefined`
    * if no text is currently selected.
    */
   public getCurrentTextSelection(): ISelection | undefined {
     this.updateTextSelection();
 
-    if (this.selectionStart === undefined || this.selectionEnd === undefined || this.selectionStart >= this.selectionEnd) {
+    if (
+      this.selectionStart === undefined ||
+      this.selectionEnd === undefined ||
+      this.selectionStart >= this.selectionEnd
+    ) {
       return undefined;
     }
 
@@ -67,14 +98,17 @@ export class NgxAnnotateTextComponent implements OnInit, OnChanges {
 
   /**
    * Checks whether the given text selection is overlapping with existing annotations.
-   * 
+   *
    * @param selection The current text selection.
    * @returns Returns `true` if the given text selection is (partially) overlapping with
    * an existing annotation. Returns `false` otherwise.
    */
   public isOverlappingWithExistingAnnotations(selection: ISelection): boolean {
     const overlappingAnnotation = this.annotations.find((annotation) => {
-      return Math.max(annotation.startIndex, selection.startIndex) < Math.min(annotation.endIndex, selection.endIndex);
+      return (
+        Math.max(annotation.startIndex, selection.startIndex) <
+        Math.min(annotation.endIndex, selection.endIndex)
+      );
     });
     return overlappingAnnotation != undefined;
   }
@@ -86,9 +120,13 @@ export class NgxAnnotateTextComponent implements OnInit, OnChanges {
 
   /** @internal */
   onRemoveAnnotation(annotation: Annotation): void {
-    this.annotations = this.annotations.filter(a => a !== annotation);
+    this.annotations = this.annotations.filter((a) => a !== annotation);
+    this.removeAnnotation.emit(annotation);
     this.annotationsChange.emit(this.annotations);
-    this.tokens = this.tokenService.splitTextIntoTokens(this.text, this.annotations);
+    this.tokens = this.tokenService.splitTextIntoTokens(
+      this.text,
+      this.annotations
+    );
   }
 
   private updateTextSelection(): void {
@@ -105,5 +143,4 @@ export class NgxAnnotateTextComponent implements OnInit, OnChanges {
       this.selectionEnd = undefined;
     }
   }
-
 }

--- a/projects/ngx-annotate-text/src/lib/models/annotation.model.ts
+++ b/projects/ngx-annotate-text/src/lib/models/annotation.model.ts
@@ -1,31 +1,40 @@
 import { ISelection } from './selection.model';
 
 export interface IAnnotation {
-    text: string | undefined;
-    label: string;
-    color: string;
+  text: string | undefined;
+  label: string;
+  color: string;
 }
 
 export class Annotation implements IAnnotation, ISelection {
-    startIndex: number;
-    endIndex: number;
-    text: string | undefined;
-    label: string;
-    color: string;
+  startIndex: number;
+  endIndex: number;
+  text: string | undefined;
+  label: string;
+  color: string;
 
-    /**
-     * Represents an annotated part of the referenced text.
-     *
-     * @param startIndex The zero-based index number indicating the beginning of this annotation.
-     * @param endIndex The zero-based index number indicating the end of the annotation. The annotation
-     * includes the characters up to, but not including, the character indicated by the end.
-     * @param label Arbitrary string displayed as label below the annotation, e. g. `City`.
-     * @param color The color of the box which is displayed around the annotation, e. g. 'red' or 'rgb(220, 53, 69)'.
-     */
-    constructor(startIndex: number, endIndex: number, label: string, color: string) {
-        this.startIndex = startIndex;
-        this.endIndex = endIndex;
-        this.label = label;
-        this.color = color;
-    }
+  /**
+   * Represents an annotated part of the referenced text.
+   *
+   * @param startIndex The zero-based index number indicating the beginning of this annotation.
+   * @param endIndex The zero-based index number indicating the end of the annotation. The annotation
+   * includes the characters up to, but not including, the character indicated by the end.
+   * @param label Arbitrary string displayed as label below the annotation, e. g. `City`.
+   * @param color The color of the box which is displayed around the annotation, e. g. 'red' or 'rgb(220, 53, 69)'.
+   */
+  constructor(
+    startIndex: number,
+    endIndex: number,
+    label: string,
+    color: string
+  ) {
+    this.startIndex = startIndex;
+    this.endIndex = endIndex;
+    this.label = label;
+    this.color = color;
+  }
+
+  toString(): String {
+    return `Annotation(startIndex=${this.startIndex}, endIndex=${this.endIndex}, label=${this.label}, color=${this.color})`;
+  }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,53 +1,72 @@
 <div class="row mt-5">
-
   <div class="col-12">
-
     <h1 class="mb-5 display-4">ngx-annotate-text demo</h1>
 
-    <ngx-annotate-text [(annotations)]="annotations" [removable]="true" [text]="text" annotationClass="my-annotation"
-      #annotateText>
+    <ngx-annotate-text
+      [(annotations)]="annotations"
+      [removable]="true"
+      [text]="text"
+      annotationClass="my-annotation"
+      (clickAnnotation)="onClickAnnotation($event)"
+      (removeAnnotation)="onRemoveAnnotation($event)"
+      #annotateText
+    >
     </ngx-annotate-text>
-
   </div>
-
 </div>
 
 <div class="row mt-3">
-
-  <div class="col-12 mb-5">
-
-    <button type="button" class="btn btn-primary me-2" (click)="addAnnotation('Date', '#0d6efd')">
+  <div class="col-12">
+    <button
+      type="button"
+      class="btn btn-primary me-2"
+      (click)="addAnnotation('Date', '#0d6efd')"
+    >
       Date
     </button>
-    <button type="button" class="btn btn-secondary me-2" (click)="addAnnotation('Time', '#6c757d')">
+    <button
+      type="button"
+      class="btn btn-secondary me-2"
+      (click)="addAnnotation('Time', '#6c757d')"
+    >
       Time
     </button>
-    <button type="button" class="btn btn-success me-2" (click)="addAnnotation('Country', '#198754')">
+    <button
+      type="button"
+      class="btn btn-success me-2"
+      (click)="addAnnotation('Country', '#198754')"
+    >
       Country
     </button>
-    <button type="button" class="btn btn-danger me-2" (click)="addAnnotation('City', '#dc3545')">
+    <button
+      type="button"
+      class="btn btn-danger me-2"
+      (click)="addAnnotation('City', '#dc3545')"
+    >
       City
     </button>
-
   </div>
-
 </div>
 
-<div class="row">
-
-  <div class="col-12">
-
+<div class="row mb-5">
+  <div class="col-12 col-lg-6 mt-3">
     <h2 class="mb-3 display-5">Annotations</h2>
 
-    <ul class="list-group">
-
-      <li class="list-group-item" *ngFor="let a of annotations">
+    <ul class="list-group" style="height: 15rem; overflow-y: auto">
+      <li class="list-group-item" *ngFor="let a of annotations.reverse()">
         start: {{ a.startIndex }}, end: {{ a.endIndex }}, text: "{{ a.text }}",
         label: {{ a.label }}
       </li>
-
     </ul>
-
   </div>
 
+  <div class="col-12 col-lg-6 mt-3">
+    <h2 class="mb-3 display-5">Events</h2>
+
+    <ul class="list-group" style="height: 15rem; overflow-y: auto">
+      <li class="list-group-item" *ngFor="let e of events.reverse()">
+        {{ e }}
+      </li>
+    </ul>
+  </div>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,12 +5,13 @@ import { Annotation, NgxAnnotateTextComponent } from 'ngx-annotate-text';
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  styleUrls: ['./app.component.css'],
 })
 export class AppComponent {
   @ViewChild('annotateText') ngxAnnotateText?: NgxAnnotateTextComponent;
 
-  text = 'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
+  text =
+    'On August 1, we went on vacation to Barcelona, Spain. Our flight took off at 11:00 am.';
 
   annotations: Annotation[] = [
     new Annotation(3, 11, 'Date', '#0d6efd'),
@@ -18,6 +19,8 @@ export class AppComponent {
     new Annotation(47, 52, 'Country', '#198754'),
     new Annotation(77, 85, 'Time', '#6c757d'),
   ];
+
+  events: String[] = [];
 
   addAnnotation(label: string, color: string): void {
     if (!this.ngxAnnotateText) {
@@ -34,13 +37,21 @@ export class AppComponent {
       return;
     }
 
-    this.annotations = this.annotations.concat(
-      new Annotation(
-        selection.startIndex,
-        selection.endIndex,
-        label,
-        color,
-      ),
+    const annotation = new Annotation(
+      selection.startIndex,
+      selection.endIndex,
+      label,
+      color
     );
+    this.annotations = this.annotations.concat(annotation);
+    this.events.push(`Added '${annotation}'`);
+  }
+
+  onClickAnnotation(annotation: Annotation) {
+    this.events.push(`Clicked on '${annotation}'`);
+  }
+
+  onRemoveAnnotation(annotation: Annotation): void {
+    this.events.push(`Removed '${annotation}'`);
   }
 }


### PR DESCRIPTION
- Adds the output `clickAnnotation` to the `ngx-annotate-text` component which emits the selected annotation when the user clicks on an annotation as requested in #10.
- Adds the output `removeAnnotation` to the `ngx-annotate-text` component which emits the selected annotation when the user removes an annotation by clicking the annotation's X button in the upper right corner.